### PR TITLE
Added ViewModelBase that implements INotifyPropertyChanged

### DIFF
--- a/Source/EyesGuard.csproj
+++ b/Source/EyesGuard.csproj
@@ -100,6 +100,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="ViewModels\ViewModelBase.cs" />
     <Compile Include="Views\Animations\BlinkAnimations.cs" />
     <Compile Include="Views\Animations\MarginFadeAnimations.cs" />
     <Compile Include="Views\Animations\ShowAndFadeAnimations.cs" />

--- a/Source/Resources/Images/MenuIcons.xaml
+++ b/Source/Resources/Images/MenuIcons.xaml
@@ -1,8 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:fa="http://schemas.fontawesome.io/icons/"
-    xmlns:local="clr-namespace:EyesGuard.Resources.Images">
+    xmlns:fa="http://schemas.fontawesome.io/icons/">
 
     <fa:ImageAwesome
         x:Key="HastiUI.Menus.UserLoginMenu.Login"

--- a/Source/ViewModels/HeaderMenuViewModel.cs
+++ b/Source/ViewModels/HeaderMenuViewModel.cs
@@ -1,56 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace EyesGuard.ViewModels
+﻿namespace EyesGuard.ViewModels
 {
-    public class HeaderMenuViewModel : INotifyPropertyChanged
+    public class HeaderMenuViewModel : ViewModelBase
     {
-        private bool _isTimeItemChecked = true;
-
+       
+        public HeaderMenuViewModel()
+        {
+            IsTimeItemChecked = true;
+            ManualBreakEnabled = true;
+            IsFeedbackAvailable = true;
+        }
         public bool IsTimeItemChecked
         {
-            get { return _isTimeItemChecked; }
-            set
-            {
-                _isTimeItemChecked = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => IsTimeItemChecked); }
+            set { SetValue(() => IsTimeItemChecked, value); }
         }
-
-        private bool manualBreakEnabled = true;
 
         public bool ManualBreakEnabled
         {
-            get { return manualBreakEnabled; }
-            set
-            {
-                manualBreakEnabled = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => ManualBreakEnabled); }
+            set { SetValue(() => ManualBreakEnabled, value); }
         }
-
-        private bool isFeedbackAvailable = true;
 
         public bool IsFeedbackAvailable
         {
-            get { return isFeedbackAvailable; }
-            set
-            {
-                isFeedbackAvailable = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => IsFeedbackAvailable); }
+            set { SetValue(() => IsFeedbackAvailable, value); }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public void OnPropertyChanged([CallerMemberName]string propertyName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
+       
     }
 }

--- a/Source/ViewModels/LongBreakWindowViewModel.cs
+++ b/Source/ViewModels/LongBreakWindowViewModel.cs
@@ -1,51 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace EyesGuard.ViewModels
 {
-    public class LongBreakWindowViewModel : INotifyPropertyChanged
+    public class LongBreakWindowViewModel : ViewModelBase
     {
-        private string timeRemaining = "";
+        public LongBreakWindowViewModel()
+        {
+            TimeRemaining = string.Empty;
+            CanCancel = Visibility.Visible;
+        }
 
         public string TimeRemaining
         {
-            get
-            {
-                return timeRemaining;
-            }
-            set
-            {
-                timeRemaining = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => TimeRemaining); }
+            set { SetValue(() => TimeRemaining, value); }
         }
-
-        private Visibility _canCancel = Visibility.Visible;
 
         public Visibility CanCancel
         {
-            get
-            {
-                return _canCancel;
-            }
-            set
-            {
-                _canCancel = value;
-                OnPropertyChanged();
-            }
-        }
+            get { return GetValue(() => CanCancel); }
+            set { SetValue(() => CanCancel, value); }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void OnPropertyChanged([CallerMemberName]string propertyName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Source/ViewModels/NotifyIconViewModel.cs
+++ b/Source/ViewModels/NotifyIconViewModel.cs
@@ -1,88 +1,61 @@
-﻿using EyesGuard.Extensions;
-using FormatWith;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using FormatWith;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 namespace EyesGuard.ViewModels
 {
-    public class NotifyIconViewModel : INotifyPropertyChanged
+    public class NotifyIconViewModel : ViewModelBase
     {
-        private SolidColorBrush darkBrush = Brushes.Green;
-        private SolidColorBrush lowBrush = Brushes.Green;
-        private ImageSource source;
-        private Visibility startProtectVisibility;
-        private Visibility stopProtectVisibility;
-        private string title = string.Empty;
+
         private string _nextShortBreak;
         private string _nextLongBreak;
-        private Visibility _pausedVisibility = Visibility.Collapsed;
         private string _pauseRemaining;
 
+        public NotifyIconViewModel()
+        {
+            Title = string.Empty;
+            DarkBrush = Brushes.Green;
+            LowBrush = Brushes.Green;
+            PausedVisibility = Visibility.Collapsed;
+            NextLongBreak = string.Empty;
+            NextShortBreak = string.Empty;
+            PauseRemaining = string.Empty;
+        }
+
         public SolidColorBrush DarkBrush {
-            get => darkBrush;
-            set
-            {
-                darkBrush = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => DarkBrush); }
+            set { SetValue(() => DarkBrush, value); }
         }
 
         public SolidColorBrush LowBrush
         {
-            get => lowBrush;
-            set
-            {
-                lowBrush = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => LowBrush); }
+            set { SetValue(() => LowBrush, value); }
         }
 
         public ImageSource Source
         {
-            get => source;
-            set
-            {
-                source = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => Source); }
+            set { SetValue(() => Source, value); }
         }
+
 
         public Visibility StartProtectVisibility
         {
-            get => startProtectVisibility;
-            set
-            {
-                startProtectVisibility = value;
-                OnPropertyChanged();
-            }
+           get { return GetValue(() => StartProtectVisibility); }
+           set { SetValue(() => StartProtectVisibility, value); }
         }
 
         public Visibility StopProtectVisibility
         {
-            get => stopProtectVisibility;
-            set
-            {
-                stopProtectVisibility = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => StopProtectVisibility); }
+            set { SetValue(() => StopProtectVisibility, value); }
         }
 
         public string Title
         {
-            get => title;
-            set
-            {
-                title = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => Title); }
+            set { SetValue(() => Title, value); }
         }
 
         public string NextShortBreak
@@ -90,8 +63,7 @@ namespace EyesGuard.ViewModels
             get => _nextShortBreak;
             set
             {
-                _nextShortBreak = value;
-                OnPropertyChanged();
+                SetField(ref _nextShortBreak, value);
                 OnPropertyChanged(nameof(NextShortBreakFullText));
             }
         }
@@ -101,20 +73,15 @@ namespace EyesGuard.ViewModels
             get => _nextLongBreak;
             set
             {
-                _nextLongBreak = value;
-                OnPropertyChanged();
+                SetField(ref _nextLongBreak, value);
                 OnPropertyChanged(nameof(NextLongBreakFullText));
             }
         }
 
         public Visibility PausedVisibility
         {
-            get => _pausedVisibility;
-            set
-            {
-                _pausedVisibility = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => PausedVisibility); }
+            set { SetValue(() => PausedVisibility, value); }
         }
 
         public string PauseRemaining
@@ -122,8 +89,7 @@ namespace EyesGuard.ViewModels
             get => _pauseRemaining;
             set
             {
-                _pauseRemaining = value;
-                OnPropertyChanged();
+                SetField(ref _pauseRemaining, value);
                 OnPropertyChanged(nameof(PauseRemainingFullText));
             }
         }
@@ -148,11 +114,5 @@ namespace EyesGuard.ViewModels
 
         public string TooltipTitle => App.LocalizedEnvironment.Translation.Application.HeaderTitle;
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public void OnPropertyChanged([CallerMemberName]string propName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
-        }
     }
 }

--- a/Source/ViewModels/ShortBreakViewModel.cs
+++ b/Source/ViewModels/ShortBreakViewModel.cs
@@ -1,47 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace EyesGuard.ViewModels
+﻿namespace EyesGuard.ViewModels
 {
-    public class ShortBreakViewModel : INotifyPropertyChanged
+    public class ShortBreakViewModel : ViewModelBase
     {
-        private string shortMessage = "";
+        public ShortBreakViewModel()
+        {
+            ShortMessage = string.Empty; ;
+            TimeRemaining = string.Empty; ;
+        }
+
         public string ShortMessage
         {
-            get
-            {
-                return shortMessage;
-            }
-            set
-            {
-                shortMessage = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => ShortMessage); }
+            set { SetValue(() => ShortMessage, value); }
         }
 
-        private string timeRemaining = "";
         public string TimeRemaining
         {
-            get
-            {
-                return timeRemaining;
-            }
-            set
-            {
-                timeRemaining = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => TimeRemaining); }
+            set { SetValue(() => TimeRemaining, value); }
         }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-        public void OnPropertyChanged([CallerMemberName]string propName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
-        }
+    
     }
 }

--- a/Source/ViewModels/ShortLongBreakTimeRemainingViewModel.cs
+++ b/Source/ViewModels/ShortLongBreakTimeRemainingViewModel.cs
@@ -1,84 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace EyesGuard.ViewModels
 {
-    public class ShortLongBreakTimeRemainingViewModel : INotifyPropertyChanged
+    public class ShortLongBreakTimeRemainingViewModel : ViewModelBase
     {
-        private string _nextShortBreak = "";
-        public string NextShortBreak {
-            get
-            {
-                return _nextShortBreak;
-            }
-            set
-            {
-                _nextShortBreak = value;
-                OnPropertyChanged();
-            }
+        public ShortLongBreakTimeRemainingViewModel()
+        {
+           NextShortBreak = string.Empty; ;
+           NextLongBreak = string.Empty; ;
+           PauseTime = string.Empty; ;
+           TimeRemainingVisibility = Visibility.Visible;
         }
 
-        private string _nextLongBreak = "";
+       
+        public string NextShortBreak {
+            get { return GetValue(() => NextShortBreak); }
+            set { SetValue(() => NextShortBreak, value); }
+        }
+
+       
         public string NextLongBreak
         {
-            get
-            {
-                return _nextLongBreak;
-            }
-            set
-            {
-                _nextLongBreak = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => NextLongBreak); }
+            set { SetValue(() => NextLongBreak, value); }
         }
 
-        private string _pauseTime = "";
+
         public string PauseTime
         {
-            get
-            {
-                return _pauseTime;
-            }
-            set
-            {
-                _pauseTime = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => PauseTime); }
+            set { SetValue(() => PauseTime, value); }
         }
 
-        private Visibility _timeRemainVisibility = Visibility.Visible;
         public Visibility TimeRemainingVisibility
         {
-            get
-            {
-                return _timeRemainVisibility;
-            }
-            set
-            {
-                _timeRemainVisibility = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => TimeRemainingVisibility); }
+            set { SetValue(() => TimeRemainingVisibility, value); }
         }
 
         private bool _protectionPause = false;
         public bool IsProtectionPaused
         {
-            get
-            {
-                return _protectionPause;
-            }
+            get => _protectionPause;
+
             set
             {
-                _protectionPause = value;
-                OnPropertyChanged();
-
-                if (_protectionPause)
+                if (SetField(ref _protectionPause, value))
                 {
                     PauseVisibility = Visibility.Visible;
                     LongShortVisibility = Visibility.Collapsed;
@@ -88,37 +55,32 @@ namespace EyesGuard.ViewModels
                     PauseVisibility = Visibility.Collapsed;
                     LongShortVisibility = Visibility.Visible;
                 }
-                OnPropertyChanged("PauseVisibility");
-                OnPropertyChanged("LongShortVisibility");
+
+                OnPropertyChanged(nameof(PauseVisibility));
+                OnPropertyChanged(nameof(LongShortVisibility));
             }
         }
 
         public Visibility PauseVisibility { get; set; } = Visibility.Collapsed;
 
-        private Visibility _longShortVisibility { get; set; } = Visibility.Visible;
+        private Visibility longShortVisibility { get; set; } = Visibility.Visible;
         public Visibility LongShortVisibility {
-            get { return _longShortVisibility; }
+            get => longShortVisibility; 
             set {
-                _longShortVisibility = value;
+                longShortVisibility = value;
                 OnPropertyChanged();
             }
         }
 
-        private Visibility _idleVisibility { get; set; } = Visibility.Collapsed;
+        private Visibility idleVisibility { get; set; } = Visibility.Collapsed;
         public Visibility IdleVisibility
         {
-            get { return _idleVisibility; }
+            get => idleVisibility;
             set
             {
-                _idleVisibility = value;
+                idleVisibility = value;
                 OnPropertyChanged();
             }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName]string propertyName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Source/ViewModels/StatsViewModel.cs
+++ b/Source/ViewModels/StatsViewModel.cs
@@ -1,89 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace EyesGuard.ViewModels
+﻿namespace EyesGuard.ViewModels
 {
-    public class StatsViewModel : INotifyPropertyChanged
+    public class StatsViewModel : ViewModelBase
     {
-        private long shortCount = 0;
         public long ShortCount
         {
-            get
-            {
-                return shortCount;
-            }
-            set
-            {
-                shortCount = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => ShortCount); }
+            set { SetValue(() => ShortCount, value); }
         }
 
-        private long longCompletedCount = 0;
         public long LongCompletedCount
         {
-            get
-            {
-                return longCompletedCount;
-            }
-            set
-            {
-                longCompletedCount = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => LongCompletedCount); }
+            set { SetValue(() => LongCompletedCount, value); }
         }
 
-        private long longfailedCount = 0;
         public long LongFailedCount
         {
-            get
-            {
-                return longfailedCount;
-            }
-            set
-            {
-                longfailedCount = value;
-                OnPropertyChanged();
-            }
+
+            get { return GetValue(() => LongFailedCount); }
+            set { SetValue(() => LongFailedCount, value); }
         }
 
-        private long pauseCount = 0;
         public long PauseCount
         {
-            get
-            {
-                return pauseCount;
-            }
-            set
-            {
-                pauseCount = value;
-                OnPropertyChanged();
-            }
+            get { return GetValue(() => PauseCount); }
+            set { SetValue(() => PauseCount, value); }
         }
 
-        private long stopCount = 0;
         public long StopCount
         {
-            get
-            {
-                return stopCount;
-            }
-            set
-            {
-                stopCount = value;
-                OnPropertyChanged();
-            }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-        public void OnPropertyChanged([CallerMemberName]string propName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
+            get { return GetValue(() => PauseCount); }
+            set { SetValue(() => PauseCount, value); }
         }
     }
 }

--- a/Source/ViewModels/ViewModelBase.cs
+++ b/Source/ViewModels/ViewModelBase.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+namespace EyesGuard.ViewModels
+{
+    /// <summary>
+    /// Base class for all the viewmodels. 
+    /// Implements INotifyPropertyChanged
+    /// main idea from http://web.archive.org/web/20121105051845/http://dotnet-forum.de/blogs/thearchitect/archive/2012/11/01/die-optimale-implementierung-des-inotifypropertychanged-interfaces.aspx
+    /// </summary>
+    public abstract class ViewModelBase : INotifyPropertyChanged
+    {
+        private readonly Dictionary<string, object> propertyValueStorage;
+
+    
+        public ViewModelBase()
+        {
+            this.propertyValueStorage = new Dictionary<string, object>();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        protected virtual bool SetField<T>(ref T storage, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(storage, value))
+                return false;
+
+            storage = value;
+
+            this.OnPropertyChanged(propertyName);
+
+            return true;
+        }
+
+        protected bool SetValue<T>(Expression<Func<T>> property, T value)
+        {
+            if (!(property is LambdaExpression lambdaExpression))
+            {
+                throw new ArgumentException("Invalid lambda expression", "Lambda expression return value can't be null");
+            }
+
+            string propertyName = this.GetPropertyName(lambdaExpression);
+
+            T storedValue = this.GetValue<T>(propertyName);
+
+            if (EqualityComparer<T>.Default.Equals(storedValue, value))
+                return false;
+
+            this.propertyValueStorage[propertyName] = value;
+            this.OnPropertyChanged(propertyName);
+
+            return true;
+
+        }
+
+        protected T GetValue<T>(Expression<Func<T>> property)
+        {
+            if (!(property is LambdaExpression lambdaExpression))
+            {
+                throw new ArgumentException("Invalid lambda expression", "Lambda expression return value can't be null");
+            }
+
+            string propertyName = this.GetPropertyName(lambdaExpression);
+
+            return GetValue<T>(propertyName);
+        }
+
+        private T GetValue<T>(string propertyName)
+        {
+
+            if (propertyValueStorage.TryGetValue(propertyName, out object value))
+            {
+                return (T)value;
+            }
+            else
+            {
+                return default;
+            }
+        }
+
+        private string GetPropertyName(LambdaExpression lambdaExpression)
+        {
+            MemberExpression memberExpression;
+
+            if (lambdaExpression.Body is UnaryExpression)
+            {
+                var unaryExpression = lambdaExpression.Body as UnaryExpression;
+                memberExpression = unaryExpression.Operand as MemberExpression;
+            }
+            else
+            {
+                memberExpression = lambdaExpression.Body as MemberExpression;
+            }
+
+            return memberExpression.Member.Name;
+        }
+
+    }
+}

--- a/Source/ViewModels/WarningPageViewModel.cs
+++ b/Source/ViewModels/WarningPageViewModel.cs
@@ -1,63 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 
 namespace EyesGuard.ViewModels
 {
-    public class WarningPageViewModel : INotifyPropertyChanged
+    public class WarningPageViewModel : ViewModelBase
     {
-        private FontAwesome.WPF.FontAwesomeIcon icon;
         public FontAwesome.WPF.FontAwesomeIcon Icon
         {
-            get
-            {
-                return icon;
-            }
-            set
-            {
-                icon = value;
-                OnPropertyChanged("Icon");
-            }
+            get { return GetValue(() => Icon); }
+            set { SetValue(() => Icon, value); }
         }
 
-        private SolidColorBrush brush;
         public SolidColorBrush Brush
+
         {
-            get
-            {
-                return brush;
-            }
-            set
-            {
-                brush = value;
-                OnPropertyChanged("Brush");
-            }
+            get { return GetValue(() => Brush); }
+            set { SetValue(() => Brush, value); }
         }
 
-        private string pageTitle;
         public string PageTitle
         {
-            get
-            {
-                return pageTitle;
-            }
-            set
-            {
-                pageTitle = value;
-                OnPropertyChanged("PageTitle");
-            }
-        }
-
-
-
-        public event PropertyChangedEventHandler PropertyChanged;
-        public void OnPropertyChanged(string propName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
+            get { return GetValue(() => PageTitle); }
+            set { SetValue(() => PageTitle, value); }
         }
     }
 }


### PR DESCRIPTION
Added methods to avoid backing fields in the get/set

---
Name: Refactoring
---
I created a base class for all the view models in order to centralize the OnPropertyChange calls
Plus I have added some methods that lets you write accessor without backing fields (it hits performance but for this application I guess you may accept it)
