### PR TITLE
Allow closing short-break window #11

### DIFF
--- a/Source/EyesGuard.Data/Languages/en-US.yml
+++ b/Source/EyesGuard.Data/Languages/en-US.yml
@@ -133,6 +133,8 @@ Translation:
           You can disable this feature from TaskManager >> Startup Tab.
         AlertBeforeLongBreak: Notify me 1 minute before long-break
         AlertBeforeLongBreakToolTip: Eyes Guard notifies you one minute before a long-break.
+        ShortBreakAllowCloseWithRightCLick: Close Short-break window with a right click
+        ShortBreakAllowCloseWithRightCLickToolTip: Allow closing Short-break window with a right click.
         SystemIdle: Pause Eyes Guard when system detected as idle
         SystemIdleToolTip:
         - Eyes Guard uses system idle detection to detect if you are away from your

--- a/Source/EyesGuard.Data/Languages/ru-RU.yml
+++ b/Source/EyesGuard.Data/Languages/ru-RU.yml
@@ -110,6 +110,8 @@ Translation:
         StartupApplicationToolTip: Программа Eyes Guard запускается при загрузке системы по умолчанию. Вы можете отменить данную функцию в Диспетчере задач Windows 10 на вкладке Автозагрузка.
         AlertBeforeLongBreak: Напоминание за 1 минуту до длинного перерыва
         AlertBeforeLongBreakToolTip: Eyes Guard напомнит о длинном перерыве за 1 минуту до его начала.
+        ShortBreakAllowCloseWithRightCLick: Разрешить закрывать заставку короткого перерыва правым кликом
+        ShortBreakAllowCloseWithRightCLickToolTip: Вы сможете закрыть заставку короткого перерыва правым кликом мыши
         SystemIdle: Включать режим ожидания, если пользователь не активен
         SystemIdleToolTip:
         - Eyes Guard приостанавливает работу, если вы отошли от компьютера.

--- a/Source/EyesGuard/Configurations/ConfigurationProperties.cs
+++ b/Source/EyesGuard/Configurations/ConfigurationProperties.cs
@@ -79,6 +79,7 @@ namespace EyesGuard.Configurations
         public bool RunMinimized { get; set; } = false;
         public bool ForceUserToBreak { get; set; } = false;
         public bool OnlyOneShortBreak { get; set; } = false;
+        public bool ShortBreakAllowCloseWithRightCLick { get; set; } = false;
         public bool SaveStats { get; set; } = true;
         public bool RunAtStartUp { get { return runAtStartup; } set { runAtStartup = value; } }
         public long ShortBreaksCompleted { get; set; } = 0;

--- a/Source/EyesGuard/Views/Animations/ShowAndFadeAnimations.cs
+++ b/Source/EyesGuard/Views/Animations/ShowAndFadeAnimations.cs
@@ -15,7 +15,7 @@ namespace EyesGuard.Views.Animations
             int milliSeconds = 500,
             IEasingFunction easingFunction = null)
         {
-            if (element == null) return;
+            if (element == null || !element.IsVisible) return;
             var anim = new DoubleAnimation()
             {
                 From = 1,
@@ -37,7 +37,7 @@ namespace EyesGuard.Views.Animations
         {
             return Task.Run(async () =>
             {
-                if (element == null) return;
+                if (element == null || !element.IsVisible) return;
                 element.Dispatcher.Invoke(() => HideUsingLinearAnimation(element, milliSeconds, easingFunction));
                 await Task.Delay(milliSeconds);
             });

--- a/Source/EyesGuard/Views/Pages/Settings.xaml
+++ b/Source/EyesGuard/Views/Pages/Settings.xaml
@@ -299,6 +299,7 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                         <RowDefinition Height="10" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
@@ -394,7 +395,20 @@
                         </CheckBox>
 
                     </StackPanel>
-
+                    <StackPanel
+                        Grid.Row="6"
+                        Grid.Column="1"
+                        Margin="5"
+                        Orientation="Horizontal">
+                        <CheckBox
+                            x:Name="shortBreakAllowCloseWithRightCLick"
+                            VerticalAlignment="Center"
+                            Content="{lang:LocalizedString 'EyesGuard.Settings.UserSettings.ShortBreakAllowCloseWithRightCLick'}"
+                            Foreground="White"
+                            ToolTip="{lang:LocalizedString 'EyesGuard.Settings.UserSettings.ShortBreakAllowCloseWithRightCLickToolTip'}"
+                            Style="{DynamicResource WhiteCheckbox}">
+                        </CheckBox>
+                    </StackPanel>
                 </Grid>
 
                 <StackPanel Orientation="Horizontal">

--- a/Source/EyesGuard/Views/Pages/Settings.xaml.cs
+++ b/Source/EyesGuard/Views/Pages/Settings.xaml.cs
@@ -80,6 +80,7 @@ namespace EyesGuard.Views.Pages
             onlyOneShortbreakCheckbox.IsChecked = App.Configuration.OnlyOneShortBreak;
             storeStatsCheckbox.IsChecked = App.Configuration.SaveStats;
             alertBeforeLongbreak.IsChecked = App.Configuration.AlertBeforeLongBreak;
+            alertBeforeLongbreak.IsChecked = App.Configuration.ShortBreakAllowCloseWithRightCLick;
 
             sytemIdleCheckbox.IsChecked = App.Configuration.SystemIdleDetectionEnabled;
 
@@ -211,6 +212,7 @@ namespace EyesGuard.Views.Pages
                     App.Configuration.SaveStats = storeStatsCheckbox.IsChecked.Value;
                     App.Configuration.OnlyOneShortBreak = onlyOneShortbreakCheckbox.IsChecked.Value;
                     App.Configuration.AlertBeforeLongBreak = alertBeforeLongbreak.IsChecked.Value;
+                    App.Configuration.ShortBreakAllowCloseWithRightCLick = shortBreakAllowCloseWithRightCLick.IsChecked.Value;
                     App.Configuration.SystemIdleDetectionEnabled = sytemIdleCheckbox.IsChecked.Value;
                     App.Configuration.ApplicationLocale = (LanguagesCombo.SelectedItem as LanguageHolder)?.Name ?? FsLanguageLoader.DefaultLocale;
                     App.Configuration.UseLanguageProvedidShortMessages = UseLanguageAsSourceCheckbox.IsChecked.Value;

--- a/Source/EyesGuard/Views/Windows/ShortBreakWindow.xaml
+++ b/Source/EyesGuard/Views/Windows/ShortBreakWindow.xaml
@@ -20,7 +20,8 @@
     Topmost="True"
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    MouseRightButtonUp="ShortBreakWindow_OnMouseRightButtonUp">
     <Grid>
 
         <Grid.ColumnDefinitions>

--- a/Source/EyesGuard/Views/Windows/ShortBreakWindow.xaml.cs
+++ b/Source/EyesGuard/Views/Windows/ShortBreakWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using EyesGuard.ViewModels;
 
 namespace EyesGuard.Views.Windows
 {
@@ -29,8 +30,13 @@ namespace EyesGuard.Views.Windows
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            if (!LetItClose)
+            if (!LetItClose && !App.Configuration.ShortBreakAllowCloseWithRightCLick)
                 e.Cancel = true;
+        }
+
+        private void ShortBreakWindow_OnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            @this.Close();
         }
     }
 }


### PR DESCRIPTION
---
name: Allow closing short-break window with right click
about: Close short brake popup with right click
---

**Description**
Added an option to close the Short-break window with a right click

**PR Domain**
Which change are you proposing?

- [x] Add feature
- [ ] Fix bug
- [ ] Fix Typo
- [ ] Extend support

**Issue relation**
[This PR is related to issue #11 ]

**Screenshots**
'No Screenshots'

**Additional context**
I am avare that the closing the Short-break window does not stop the short-break timer, but I'm not sure how (and whether) I should implement it. If you have any suggestion please guide me.
This is my first commit to a open source project - any critique would be welcome. Thanks!